### PR TITLE
Add instructions for Windows 10 App Store

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ WYSIWYG A/B tests, which should restore the old editor functionality.
     * On Mac: `export SLACK_DEVELOPER_MENU=true && open -a /Applications/Slack.app`
     * On PC in a Powershell window (per user install): `$env:SLACK_DEVELOPER_MENU="true"; & "$($env:LOCALAPPDATA)\Slack\slack.exe"`
     * On PC in a Powershell window (machine wide install): `$env:SLACK_DEVELOPER_MENU="true"; & "$($Env:ProgramFiles)\Slack Deployment\slack.exe"`
+    * On PC with slack managed by the Windows 10 App Store: uninstall slack, [download the exe](https://slack.com/downloads/windows), and follow one of the above instructions
     * On other OS's: ensure the `SLACK_DEVELOPER_MENU` environment variable is set to `true` before opening the Slack app.
 2. Right-click in the app and _Inspect element_
 3. Copy the contents of `index.js`


### PR DESCRIPTION
For all I know, it may be possible to run slack in developer mode from
the app store, but I didn't see an obvious way to do it, and
uninstalling then reinstalling is quick and easy to do.

This is just a documentation PR.