### PR TITLE
Add a convenience script for the app on Linux and MacOS

### DIFF
--- a/slack.sh
+++ b/slack.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+# Enable developer tools so that this can be run in the app https://github.com/ksandom/slack-disable-wysiwyg-bookmarklet
+
+function toClipboard
+{
+  if command -v pbcopy > /dev/null; then
+    pbcopy
+  elif command -v xclip > /dev/null; then
+    xclip -i -selection c
+  else
+    echo "No clipboard tool found. Here's what you need to paste into the developer console:"
+    cat -
+  fi
+}
+
+curl https://raw.githubusercontent.com/kfahy/slack-disable-wysiwyg-bookmarklet/master/index.js | toClipboard
+
+SLACK_DEVELOPER_MENU=true slack

--- a/slack.sh
+++ b/slack.sh
@@ -15,4 +15,12 @@ function toClipboard
 
 curl https://raw.githubusercontent.com/kfahy/slack-disable-wysiwyg-bookmarklet/master/index.js | toClipboard
 
-SLACK_DEVELOPER_MENU=true slack
+export SLACK_DEVELOPER_MENU=true
+
+if command -v slack > /dev/null; then
+  slack
+elif command -v /Applications/Slack.app/Contents/MacOS/Slack > /dev/null; then
+  /Applications/Slack.app/Contents/MacOS/Slack
+else
+  echo "I can't find slack installed on this machine. Oh well, you should still have the code in your clipboard to paste into your browser."
+fi


### PR DESCRIPTION
* Grabs the latest code, and puts it into your clipboard.
* Starts slack with `SLACK_DEVELOPER_MENU=true`.
* At that point, all you have to do is the 
  * Right click.
  * Inspect.
  * Click console.
  * CTRL/CMD + v enter
  * Close

Still way more steps than it should be. But another step forward.