### PR TITLE
Add simplified browser bookmarklet snippet

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,12 +30,13 @@ For bugs, feedback, and source, visit the extension repo
 
 ### Browser bookmarklet
 
-1. Copy the contents of `index.js`
-2. Paste into the URL field of a browser bookmark, and prepend the text with
-   `javascript:`
+1. Copy the contents of [`browser.js`](./browser.js)
+2. Paste into the URL field of a browser bookmark
 3. Navigate to a Slack workspace in that browser
 4. Execute the bookmarklet to disable the WYSIWYG editor
 5. Repeat each time you reload slack
+
+> **Chrome**: Visit `chrome://bookmarks/`, drag and drop this bookmarklet in visible area of bookmarks bar at top so you can execute it anytime.
 
 ### In the desktop app
 

--- a/browser.js
+++ b/browser.js
@@ -1,5 +1,3 @@
-javascript:(_ => {
-  const {redux} = slackDebug.activeTeam;
-  const {wysiwyg_composer, wysiwyg_composer_ios, wysiwyg_composer_webapp, ...payload} = redux.getState().experiments;
-  redux.dispatch({type: '[19] Bulk add experiment assignments to redux', payload});
-})();
+javascript:
+['', '_ios', '_webapp'].map(w => delete slackDebug.activeTeam.redux.getState().experiments['wysiwyg_composer' + w]);
+setTimeout(_ => document.querySelector('[type=paperclip]').click(), 9)

--- a/browser.js
+++ b/browser.js
@@ -1,0 +1,5 @@
+javascript:(_ => {
+  const {redux} = slackDebug.activeTeam;
+  const {wysiwyg_composer, wysiwyg_composer_ios, wysiwyg_composer_webapp, ...payload} = redux.getState().experiments;
+  redux.dispatch({type: '[19] Bulk add experiment assignments to redux', payload});
+})();


### PR DESCRIPTION
Reference: https://github.com/kfahy/slack-disable-wysiwyg-bookmarklet/pull/2#issuecomment-557397274

It further shortens code from 02a8285 by 88bytes