### PR TITLE
Update `README` with steps to launch Slack in Developer mode on Ubuntu

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,9 @@ Download and run
     * On Mac: `export SLACK_DEVELOPER_MENU=true && open -a /Applications/Slack.app`
     * On PC in a Powershell window (per user install): `$env:SLACK_DEVELOPER_MENU="true"; & "$($env:LOCALAPPDATA)\Slack\slack.exe"`
     * On PC in a Powershell window (machine wide install): `$env:SLACK_DEVELOPER_MENU="true"; & "$($Env:ProgramFiles)\Slack Deployment\slack.exe"`
+    * On Ubuntu with Gnome (using Slack launcher):
+        * edit `/usr/share/applications/slack.desktop`
+        * replace `Exec=/usr/bin/slack %U` with `Exec=env SLACK_DEVELOPER_MENU=true /usr/bin/slack %U`
     * On other OS's: ensure the `SLACK_DEVELOPER_MENU` environment variable is set to `true` before opening the Slack app.
 2. Right-click in the app and _Inspect element_
 3. Copy the contents of `index.js`

--- a/README.md
+++ b/README.md
@@ -44,12 +44,12 @@ For bugs, feedback, and source, visit the extension repo
 Download and run
 [`bin/patch-desktop-app`](https://github.com/kfahy/slack-disable-wysiwyg-bookmarklet/blob/master/bin/patch-desktop-app), courtesy of [@dbalatero](https://github.com/dbalatero).
 
-#### Option B: Manually execute script for Mac or other platforms
+#### Option B: Manually execute script
 
 1. Open the slack app in Developer mode
-    * On Mac: `export SLACK_DEVELOPER_MENU=true && open -a /Applications/Slack.app`
-    * On PC in a Powershell window (per user install): `$env:SLACK_DEVELOPER_MENU="true"; & "$($env:LOCALAPPDATA)\Slack\slack.exe"`
-    * On PC in a Powershell window (machine wide install): `$env:SLACK_DEVELOPER_MENU="true"; & "$($Env:ProgramFiles)\Slack Deployment\slack.exe"`
+    * On Mac OS X: `export SLACK_DEVELOPER_MENU=true && open -a /Applications/Slack.app`
+    * On Windows in a Powershell window (per user install): `$env:SLACK_DEVELOPER_MENU="true"; & "$($env:LOCALAPPDATA)\Slack\slack.exe"`
+    * On Windows in a Powershell window (machine wide install): `$env:SLACK_DEVELOPER_MENU="true"; & "$($Env:ProgramFiles)\Slack Deployment\slack.exe"`
     * On Ubuntu with Gnome (using Slack launcher):
         * edit `/usr/share/applications/slack.desktop`
         * replace `Exec=/usr/bin/slack %U` with `Exec=env SLACK_DEVELOPER_MENU=true /usr/bin/slack %U`


### PR DESCRIPTION
Update `README` with steps to launch Slack in Developer mode on Ubuntu.